### PR TITLE
mb_str_split(): length can't be a negative number

### DIFF
--- a/src/mb_helpers.php
+++ b/src/mb_helpers.php
@@ -122,7 +122,7 @@ if (!function_exists('mb_str_split')) {
      */
     function mb_str_split($string, $split_length = 1, $encoding = 'UTF-8')
     {
-        if ($split_length == 0) {
+        if ($split_length <= 0) {
             throw new \Exception('The length of each segment must be greater than zero');
         }
 

--- a/tests/mb_helpersTest.php
+++ b/tests/mb_helpersTest.php
@@ -65,6 +65,17 @@ class HelpersTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(str_split('bobby'), mb_str_split('bobby'));
         $this->assertEquals(str_split(''), mb_str_split(''));
+
+        foreach(array(0,-1) as $length) {
+          $exception_thrown = false;
+          try {
+             mb_str_split('foo', $length);
+          } catch (Exception $e) {
+             $exception_thrown = true;
+             $this->assertEquals('The length of each segment must be greater than zero', $e->getMessage());
+          }
+          $this->assertTrue($exception_thrown);
+        }
     }
 
 }


### PR DESCRIPTION
Hi, I just found a small bug in mb_str_split().